### PR TITLE
Update AttachmentService.php

### DIFF
--- a/services/wechat/AttachmentService.php
+++ b/services/wechat/AttachmentService.php
@@ -422,9 +422,9 @@ class AttachmentService extends Service
                 break;
         }
 
-        if ($total - $count > 0) {
+        if ($total - ($offset + $count) > 0) {
             return [
-                'offset' => ($offset + 1) * $count,
+                 'offset' => ($offset + $count),
                 'count' => $count
             ];
         }


### PR DESCRIPTION
修复死循环和偏移算法问题。原代码if ($total - $count > 0) 存在死循环，因为$count=20是一个定值。'offset' => ($offset + 1) * $count算法也有问题，加上死循环，导致offset累加0、20、420、8420...一直到溢出。