### PR TITLE
Update ExcelHelper.php

### DIFF
--- a/common/helpers/ExcelHelper.php
+++ b/common/helpers/ExcelHelper.php
@@ -44,7 +44,7 @@ class ExcelHelper
         // 写入头部
         $hk = 1;
         foreach ($header as $k => $v) {
-            $sheet->setCellValue(Coordinate::stringFromColumnIndex($hk) . '1', $v[0]);
+            $sheet->setCellValue(Coordinate::stringFromColumnIndex($hk) . '1', $v);
             $hk += 1;
         }
 
@@ -59,7 +59,8 @@ class ExcelHelper
 
                 foreach ($header as $key => $value) {
                     // 解析字段
-                    $realData = self::formatting($header[$key], trim(self::formattingField($row, $value[1])), $row);
+                    //$realData = self::formatting($header[$key], trim(self::formattingField($row, $value[1])), $row);
+                    $realData = $row[$key];
                     // 写入excel
                     $sheet->setCellValue(Coordinate::stringFromColumnIndex($span) . $column, $realData);
                     $span++;
@@ -246,7 +247,7 @@ class ExcelHelper
      * @param array $array 头部规则
      * @return false|mixed|null|string 内容值
      */
-    protected static function formatting(array $array, $value, $row)
+    protected static function formatting( $array, $value, $row)
     {
         !isset($array[2]) && $array[2] = 'text';
 


### PR DESCRIPTION
修正：exportData方法的表格header部分只有一个字母的bug
修改：解析字段部分，改成只接受文本。 不再支持函数、下拉框等
修改： formatting方法第一个形参固定为array，导致在不同版本的环境下容易报错，去除这个显示声明。