### PR TITLE
fix 选择素材翻页时的链接错误;fix 商户端接收微信消息时，未指定商户ID无法正常找到商户的微信公众号的配置参数

### DIFF
--- a/addons/Wechat/merchant/views/selector/selector.php
+++ b/addons/Wechat/merchant/views/selector/selector.php
@@ -116,7 +116,7 @@ use yii\helpers\ArrayHelper;
     function rfGetAttachment() {
         $.ajax({
             type:"get",
-            url:"<?= Url::to(['/selector/list', 'media_type' => $media_type, 'json' => true])?>",
+            url:"<?= Url::to(['/wechat/selector/list', 'media_type' => $media_type, 'json' => true])?>",
             dataType: "json",
             data: {
                 page:page,

--- a/common/helpers/WechatHelper.php
+++ b/common/helpers/WechatHelper.php
@@ -21,7 +21,7 @@ class WechatHelper
      */
     public static function verifyToken($signature, $timestamp, $nonce)
     {
-        $config = Yii::$app->debris->configAll(true);
+        $config = Yii::$app->debris->configAll(true,Yii::$app->services->merchant->getId());
         $token = $config['wechat_token'] ?? '';
         $tmpArr = [$token, $timestamp, $nonce];
         sort($tmpArr, SORT_STRING);


### PR DESCRIPTION
fix 选择素材翻页时的链接错误;
fix 商户端接收微信消息时，未指定商户ID无法正常找到商户的微信公众号的配置参数