### PR TITLE
$this应指模当前使用的模块名id

### DIFF
--- a/common/components/Wechat.php
+++ b/common/components/Wechat.php
@@ -35,7 +35,7 @@ class Wechat extends \jianyan\easywechat\Wechat
         $config = Yii::$app->debris->merchantConfigAll();
 
         $callbackUrl = $notifyUrl = '';
-        if (!empty($this->id) && $this->id != AppEnum::CONSOLE) {
+        if (!empty(Yii::$app->id) && Yii::$app->id != AppEnum::CONSOLE) {
             $callbackUrl = Yii::$app->request->hostInfo . Yii::$app->request->getUrl();
             $notifyUrl = Yii::$app->request->hostInfo . Yii::$app->urlManager->createUrl(['notify/index']);
         }


### PR DESCRIPTION
做Html5应用的时候，发现始终无法调到回调地址发现的BUG.