### PR TITLE
在Merchant端调用微信设置时,结果没有按商户ID进行保存和调用

### DIFF
--- a/services/common/ConfigCateService.php
+++ b/services/common/ConfigCateService.php
@@ -85,7 +85,10 @@ class ConfigCateService extends Service
             ->orderBy('sort asc')
             ->with(['config' => function($query) use ($app_id) {
                 /** @var ActiveQuery $query */
-                return $query->andWhere(['app_id' => $app_id])->with('value');
+                return $query->andWhere(['app_id' => $app_id])
+                    ->with(['value' => function($query){
+                        return $query->andWhere(['merchant_id' => $this->getMerchantId()]);
+                    }]);
             }])
             ->asArray()
             ->all();

--- a/services/common/ConfigService.php
+++ b/services/common/ConfigService.php
@@ -26,10 +26,13 @@ class ConfigService extends Service
      */
     public function updateAll($app_id, $data)
     {
+        $merchant_id = Yii::$app->services->merchant->getId();
         $config = Config::find()
             ->where(['in', 'name', array_keys($data)])
             ->andWhere(['app_id' => $app_id])
-            ->with('value')
+            ->with(['value' => function($query) use($merchant_id){
+                return $query->andWhere(['merchant_id' => $merchant_id]);
+            }])
             ->all();
 
         foreach ($config as $item) {
@@ -37,6 +40,7 @@ class ConfigService extends Service
             /** @var ConfigValue $model */
             $model = $item->value ?? new ConfigValue();
             $model->config_id = $item->id;
+            $model->merchant_id = $merchant_id;
             $model->data = is_array($val) ? Json::encode($val) : $val;
             $model->save();
         }


### PR DESCRIPTION
在Merchant端存在多个商户时，显示的数据为第一商户的信息。
调用微信设置时,结果没有按商户ID进行保存和调用。