### PR TITLE
添加商户端生成模板

### DIFF
--- a/common/components/gii/crud/merchant/controller.php
+++ b/common/components/gii/crud/merchant/controller.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * This is the template for generating a CRUD controller class file.
+ */
+
+use yii\db\ActiveRecordInterface;
+use yii\helpers\StringHelper;
+
+
+/* @var $this yii\web\View */
+/* @var $generator yii\gii\generators\crud\Generator */
+
+$controllerClass = StringHelper::basename($generator->controllerClass);
+$modelClass = StringHelper::basename($generator->modelClass);
+
+/* @var $class ActiveRecordInterface */
+$class = $generator->modelClass;
+$pks = $class::primaryKey();
+$urlParams = $generator->generateUrlParams();
+$actionParams = $generator->generateActionParams();
+$actionParamComments = $generator->generateActionParamComments();
+
+echo "<?php\n";
+?>
+
+namespace <?= StringHelper::dirname(ltrim($generator->controllerClass, '\\')) ?>;
+
+use Yii;
+use common\enums\StatusEnum;
+use <?= ltrim($generator->modelClass, '\\') ?>;
+use common\traits\MerchantCurd;
+use common\models\base\SearchModel;
+use <?= ltrim($generator->baseControllerClass, '\\') ?>;
+
+/**
+* <?= $modelClass . "\n" ?>
+*
+* Class <?= $controllerClass . "\n" ?>
+* @package <?= StringHelper::dirname(ltrim($generator->controllerClass, '\\')) . "\n" ?>
+*/
+class <?= $controllerClass ?> extends <?= StringHelper::basename($generator->baseControllerClass) . "\n" ?>
+{
+
+    use MerchantCurd;
+
+    /**
+    * @var <?= $modelClass . "\n" ?>
+    */
+    public $modelClass = <?= $modelClass ?>::class;
+
+
+    /**
+    * 首页
+    *
+    * @return string
+    * @throws \yii\web\NotFoundHttpException
+    */
+    public function actionIndex()
+    {
+        $searchModel = new SearchModel([
+            'model' => $this->modelClass,
+            'scenario' => 'default',
+            'partialMatchAttributes' => [], // 模糊查询
+            'defaultOrder' => [
+                // 'sort' => SORT_ASC,
+                'id' => SORT_DESC
+            ],
+            'pageSize' => $this->pageSize
+        ]);
+
+        $dataProvider = $searchModel
+            ->search(Yii::$app->request->queryParams);
+
+        $dataProvider->query
+            ->andWhere(['>=', 'status', StatusEnum::DISABLED])
+            ->andFilterWhere(['merchant_id' => $this->getMerchantId()]);
+
+        return $this->render($this->action->id, [
+            'dataProvider' => $dataProvider,
+            'searchModel' => $searchModel,
+        ]);
+    }
+
+}

--- a/common/components/gii/crud/merchant/views/edit.php
+++ b/common/components/gii/crud/merchant/views/edit.php
@@ -1,0 +1,67 @@
+<?php
+
+use yii\helpers\Inflector;
+use yii\helpers\StringHelper;
+
+/* @var $this yii\web\View */
+/* @var $generator yii\gii\generators\crud\Generator */
+
+/* @var $model \yii\db\ActiveRecord */
+$model = new $generator->modelClass();
+$safeAttributes = $model->safeAttributes();
+if (empty($safeAttributes)) {
+    $safeAttributes = $model->attributes();
+}
+
+echo "<?php\n";
+?>
+
+use common\helpers\Html;
+use yii\widgets\ActiveForm;
+
+/* @var $this yii\web\View */
+/* @var $model <?= ltrim($generator->modelClass, '\\') ?> */
+/* @var $form yii\widgets\ActiveForm */
+
+$this->title = '编辑';
+$this->params['breadcrumbs'][] = ['label' => <?= $generator->generateString(Inflector::pluralize(Inflector::camel2words(StringHelper::basename($generator->modelClass)))) ?>, 'url' => ['index']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="row">
+    <div class="col-lg-12">
+        <div class="box">
+            <div class="box-header with-border">
+                <h3 class="box-title">基本信息</h3>
+            </div>
+            <div class="box-body">
+                <?= "<?php " ?>$form = ActiveForm::begin([
+                    'fieldConfig' => [
+                        'template' => "<div class='col-sm-2 text-right'>{label}</div><div class='col-sm-10'>{input}\n{hint}\n{error}</div>",
+                    ],
+                ]); ?>
+                <div class="col-sm-12">
+<?php
+if (!empty($generator->formFields)) {
+    foreach ($generator->formFields as $attribute) {
+        echo "                    <?= " . $generator->generateActiveField($attribute) . " ?>\n";
+    }
+} else {
+    foreach ($generator->getColumnNames() as $attribute) {
+        if (in_array($attribute, $safeAttributes)) {
+            echo "                    <?= " . $generator->generateActiveField($attribute) . " ?>\n";
+        }
+    }
+}?>
+                </div>
+                <div class="form-group">
+                    <div class="col-sm-12 text-center">
+                        <button class="btn btn-primary" type="submit">保存</button>
+                        <span class="btn btn-white" onclick="history.go(-1)">返回</span>
+                    </div>
+                </div>
+                <?= "<?php " ?>ActiveForm::end(); ?>
+            </div>
+        </div>
+    </div>
+</div>

--- a/common/components/gii/crud/merchant/views/index.php
+++ b/common/components/gii/crud/merchant/views/index.php
@@ -1,0 +1,98 @@
+<?php
+
+use yii\helpers\Inflector;
+use yii\helpers\StringHelper;
+
+/* @var $this yii\web\View */
+/* @var $generator yii\gii\generators\crud\Generator */
+
+$urlParams = $generator->generateUrlParams();
+$nameAttribute = $generator->getNameAttribute();
+
+echo "<?php\n";
+?>
+
+use common\helpers\Html;
+use common\helpers\Url;
+use <?= $generator->indexWidgetType === 'grid' ? "yii\\grid\\GridView" : "yii\\widgets\\ListView" ?>;
+
+/* @var $this yii\web\View */
+/* @var $dataProvider yii\data\ActiveDataProvider */
+
+$this->title = <?= $generator->generateString(Inflector::pluralize(Inflector::camel2words(StringHelper::basename($generator->modelClass)))) ?>;
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="row">
+    <div class="col-xs-12">
+        <div class="box">
+            <div class="box-header">
+                <h3 class="box-title"><?= "<?= " ?>Html::encode($this->title) ?></h3>
+                <div class="box-tools">
+                    <?= "<?= " ?>Html::create(['edit']) ?>
+                </div>
+            </div>
+            <div class="box-body table-responsive">
+<?php if ($generator->indexWidgetType === 'grid'): ?>
+    <?= "<?= " ?>GridView::widget([
+        'dataProvider' => $dataProvider,
+        'tableOptions' => ['class' => 'table table-hover'],
+        <?= !empty($generator->searchModelClass) ? "'filterModel' => \$searchModel,\n        'columns' => [\n" : "'columns' => [\n"; ?>
+            [
+                'class' => 'yii\grid\SerialColumn',
+                'visible' => false,
+            ],
+
+<?php
+$count = 0;
+if (($tableSchema = $generator->getTableSchema()) === false) {
+    foreach ($generator->getColumnNames() as $name) {
+        if (++$count < 6) {
+            echo "            '" . $name . "',\n";
+        } else {
+            echo "            //'" . $name . "',\n";
+        }
+    }
+} else {
+    $listFields = !empty($generator->listFields) ? $generator->listFields : [];
+    foreach ($tableSchema->columns as $column) {
+        $format = $generator->generateColumnFormat($column);
+        if (in_array($column->name, $listFields)) {
+            echo "            '" . $column->name . ($format === 'text' ? "" : ":" . $format) . "',\n";
+        } else {
+            echo "            //'" . $column->name . ($format === 'text' ? "" : ":" . $format) . "',\n";
+        }
+    }
+}
+?>
+            [
+                'class' => 'yii\grid\ActionColumn',
+                'header' => '操作',
+                'template' => '{edit} {status} {delete}',
+                'buttons' => [
+                'edit' => function($url, $model, $key){
+                        return Html::edit(['edit', 'id' => $model->id]);
+                },
+               'status' => function($url, $model, $key){
+                        return Html::status($model['status']);
+                  },
+                'delete' => function($url, $model, $key){
+                        return Html::delete(['delete', 'id' => $model->id]);
+                },
+                ]
+            ]
+    ]
+    ]); ?>
+<?php else: ?>
+    <?= "<?= " ?>ListView::widget([
+        'dataProvider' => $dataProvider,
+        'itemOptions' => ['class' => 'item'],
+        'itemView' => function ($model, $key, $index, $widget) {
+            return Html::a(Html::encode($model-><?= $nameAttribute ?>), ['view', <?= $urlParams ?>]);
+        },
+    ]) ?>
+<?php endif; ?>
+            </div>
+        </div>
+    </div>
+</div>

--- a/common/components/gii/model/merchant/model.php
+++ b/common/components/gii/model/merchant/model.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * This is the template for generating the model class of a specified table.
+ */
+
+/* @var $this yii\web\View */
+/* @var $generator yii\gii\generators\model\Generator */
+/* @var $tableName string full table name */
+/* @var $className string class name */
+/* @var $queryClassName string query class name */
+/* @var $tableSchema yii\db\TableSchema */
+/* @var $properties array list of properties (property => [type, name. comment]) */
+/* @var $labels string[] list of attribute labels (name => label) */
+/* @var $rules string[] list of validation rules */
+/* @var $relations array list of relations (name => relation declaration) */
+
+echo "<?php\n";
+?>
+
+namespace <?= $generator->ns ?>;
+
+use Yii;
+use common\behaviors\MerchantBehavior;
+
+/**
+ * This is the model class for table "<?= $generator->generateTableName($tableName) ?>".
+ *
+<?php foreach ($properties as $property => $data): ?>
+ * @property <?= "{$data['type']} \${$property}"  . ($data['comment'] ? ' ' . strtr($data['comment'], ["\n" => ' ']) : '') . "\n" ?>
+<?php endforeach; ?>
+<?php if (!empty($relations)): ?>
+ *
+<?php foreach ($relations as $name => $relation): ?>
+ * @property <?= $relation[1] . ($relation[2] ? '[]' : '') . ' $' . lcfirst($name) . "\n" ?>
+<?php endforeach; ?>
+<?php endif; ?>
+ */
+class <?= $className ?> extends <?= '\\' . ltrim($generator->baseClass, '\\') . "\n" ?>
+{
+
+    use MerchantBehavior;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function tableName()
+    {
+        return '<?= $generator->generateTableName($tableName) ?>';
+    }
+<?php if ($generator->db !== 'db'): ?>
+
+    /**
+     * @return \yii\db\Connection the database connection used by this AR class.
+     */
+    public static function getDb()
+    {
+        return Yii::$app->get('<?= $generator->db ?>');
+    }
+<?php endif; ?>
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rules()
+    {
+        return [<?= empty($rules) ? '' : ("\n            " . implode(",\n            ", $rules) . ",\n        ") ?>];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function attributeLabels()
+    {
+        return [
+<?php foreach ($labels as $name => $label): ?>
+            <?= "'$name' => " . (!empty($properties[$name]['comment']) ? "'{$properties[$name]['comment']}'": $generator->generateString($label)) . ",\n" ?>
+<?php endforeach; ?>
+        ];
+    }
+<?php foreach ($relations as $name => $relation): ?>
+
+    /**
+     * @return \yii\db\ActiveQuery
+     */
+    public function get<?= $name ?>()
+    {
+        <?= $relation[0] . "\n" ?>
+    }
+<?php endforeach; ?>
+<?php if ($queryClassName): ?>
+<?php
+    $queryClassFullName = ($generator->ns === $generator->queryNs) ? $queryClassName : '\\' . $generator->queryNs . '\\' . $queryClassName;
+    echo "\n";
+?>
+    /**
+     * {@inheritdoc}
+     * @return <?= $queryClassFullName ?> the active query used by this AR class.
+     */
+    public static function find()
+    {
+        return new <?= $queryClassFullName ?>(get_called_class());
+    }
+<?php endif; ?>
+}

--- a/common/components/gii/model/merchant/query.php
+++ b/common/components/gii/model/merchant/query.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This is the template for generating the ActiveQuery class.
+ */
+
+/* @var $this yii\web\View */
+/* @var $generator yii\gii\generators\model\Generator */
+/* @var $tableName string full table name */
+/* @var $className string class name */
+/* @var $tableSchema yii\db\TableSchema */
+/* @var $labels string[] list of attribute labels (name => label) */
+/* @var $rules string[] list of validation rules */
+/* @var $relations array list of relations (name => relation declaration) */
+/* @var $className string class name */
+/* @var $modelClassName string related model class name */
+
+$modelFullClassName = $modelClassName;
+if ($generator->ns !== $generator->queryNs) {
+    $modelFullClassName = '\\' . $generator->ns . '\\' . $modelFullClassName;
+}
+
+echo "<?php\n";
+?>
+
+namespace <?= $generator->queryNs ?>;
+
+/**
+ * This is the ActiveQuery class for [[<?= $modelFullClassName ?>]].
+ *
+ * @see <?= $modelFullClassName . "\n" ?>
+ */
+class <?= $className ?> extends <?= '\\' . ltrim($generator->queryBaseClass, '\\') . "\n" ?>
+{
+    /*public function active()
+    {
+        return $this->andWhere('[[status]]=1');
+    }*/
+
+    /**
+     * {@inheritdoc}
+     * @return <?= $modelFullClassName ?>[]|array
+     */
+    public function all($db = null)
+    {
+        return parent::all($db);
+    }
+
+    /**
+     * {@inheritdoc}
+     * @return <?= $modelFullClassName ?>|array|null
+     */
+    public function one($db = null)
+    {
+        return parent::one($db);
+    }
+}

--- a/common/traits/Curd.php
+++ b/common/traits/Curd.php
@@ -139,7 +139,7 @@ trait Curd
         $this->activeFormValidate($model);
         if ($model->load(Yii::$app->request->post())) {
             return $model->save()
-                ? $this->redirect(['index'])
+                ? $this->redirect(Yii::$app->request->referrer)
                 : $this->message($this->getError($model), $this->redirect(['index']), 'error');
         }
 

--- a/common/traits/MerchantCurd.php
+++ b/common/traits/MerchantCurd.php
@@ -141,7 +141,7 @@ trait MerchantCurd
         $this->activeFormValidate($model);
         if ($model->load(Yii::$app->request->post())) {
             return $model->save()
-                ? $this->redirect(['index'])
+                ? $this->redirect(Yii::$app->request->referrer)
                 : $this->message($this->getError($model), $this->redirect(['index']), 'error');
         }
 


### PR DESCRIPTION
添加商户端生成模板，在做商户端的时候，使用的是后台生成的代码，生成后，还需要改动。如果开发插件，生成模型和商户端的功能页，仍需要调整。为了方便，直接copy了后台生成的代码，稍作改动用于商户端的模型生成和代码生成。